### PR TITLE
Fixes formatting the selected zone or current line

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ function executeOcpIndent(document: vscode.TextDocument, option: string) {
 function makeOptionRange({ start, end }: vscode.Range) {
 	let result = "";
 	if (start.line !== end.line || start.character !== end.character) {
-		result = ' -l ' + start.line + '-' + end.line;
+		result = ' -l ' + (start.line + 1) + '-' + (end.line + 1);
 	}
 	return result;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ function ocpIndentPath(): string {
 
 function ocpCommand() {
 	const path = ocpIndentPath();
-	if (path === ""){
+	if (path === "") {
 		return 'ocp-indent';
 	} else {
 		return path;
@@ -46,7 +46,7 @@ function doIndentZone(document: vscode.TextDocument, range: any): string | undef
 	}
 	else if (globalFormatSelection()) {
 		let editor = vscode.window.activeTextEditor;
-		if (editor) {
+		if (editor && editor.selection.start.isBefore(editor.selection.end)) {
 			optionLines = makeOptionRange(editor.selection);
 		}
 	}


### PR DESCRIPTION
- Fixes the line numbers used when formatting only the selected zone.   
  Allows formatting only the current line when nothing is selected. 
- Do not let `ocp-indent` modifies the files via `--inplace`; instead, returns the difference as TextEdit to vscode.
  Fixes issues with the cursor location moving when the file was modified by `ocp-indent`.