### PR TITLE
Spawn ocp-indent in the file's directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Upcoming
+
+- Set the current working directory in order to use .ocp-indent file settings ([@mlasson](https://github.com/mlasson))
+
 ## [0.2]
 
 - Changes communication with `ocp-indent` (more robust)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ocp-indent",
   "displayName": "OcpIndent",
   "description": "Provide OCP Indent in VSCode",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "AllanBlanchard",
   "repository": {
     "url": "https://github.com/AllanBlanchard/vscode-ocp-indent"
@@ -52,7 +52,7 @@
     "@typescript-eslint/parser": "^4.14.1",
     "eslint": "^7.19.0",
     "glob": "^7.1.6",
-    "mocha": "^8.2.1",
+    "mocha": "^10.2.0",
     "typescript": "^4.1.3",
     "vscode-test": "^1.5.0"
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,12 +20,33 @@ function ocpCommand() {
 	}
 }
 
+function getCwd(document: vscode.TextDocument): string | undefined {
+	const uri = document.uri;
+	// Check if the document has a file path
+	if (uri.scheme === 'file') {
+		const path = require("path");
+		const filePath = uri.fsPath;
+		return path.dirname(filePath);
+	} else {
+		// Otherwise, we -arbitrarily- use the first workspace root
+		const workspaceFolders = vscode.workspace.workspaceFolders;
+		if (workspaceFolders && workspaceFolders.length > 0) {
+			return workspaceFolders[0].uri.fsPath;
+		} else {
+			// In the worst case, we give up.
+			return undefined;
+		}
+	}
+}
+
 function executeOcpIndent(document: vscode.TextDocument, args: string[]): string | undefined {
 	const cmd = ocpCommand();
 	const text = document.getText();
+	const cwd =	getCwd(document);
 	const options = {
 		input: text,
 		encoding: 'utf8',
+		cwd: cwd
 	};
 	const cp = require('child_process');
 	const { stdout, stderr, error } = cp.spawnSync(cmd, args, options);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ function executeOcpIndent(document: vscode.TextDocument, args: string[]): string
 	const cp = require('child_process');
 	const { stdout, stderr, error } = cp.spawnSync(cmd, args, options);
 	if (stderr) { vscode.window.showErrorMessage(stderr); }
-	if (error) { vscode.window.showErrorMessage(error); }
+	if (error) { vscode.window.showErrorMessage(error.message); }
 	const output = error || stderr ? undefined : stdout;
 	return output;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ function getCwd(document: vscode.TextDocument): string | undefined {
 function executeOcpIndent(document: vscode.TextDocument, args: string[]): string | undefined {
 	const cmd = ocpCommand();
 	const text = document.getText();
-	const cwd =	getCwd(document);
+	const cwd = getCwd(document);
 	const options = {
 		input: text,
 		encoding: 'utf8',


### PR DESCRIPTION
Hello, 

`ocp-indent` looks for the `.ocp-indent` configuration file in the current working directory and its ancestors.  This PR makes sure that we change the current working directory to the file's dirname before spawning the process. 

When the file is not yet saved on the disk, we fallback to the first "root folder" if it exists. 

The PR also contains a tiny fix for displaying system errors. 

~I'm currently testing the PR, please do not merge yet~. 

Thanks !